### PR TITLE
Fix Create heated mixing recipes using invalid JSON

### DIFF
--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/brass.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/brass.json
@@ -28,5 +28,5 @@
       "count": 4
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/bronze.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/bronze.json
@@ -28,5 +28,5 @@
       "count": 4
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/constantan.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/constantan.json
@@ -22,5 +22,5 @@
       "count": 2
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/electrum.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/electrum.json
@@ -22,5 +22,5 @@
       "count": 2
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/enderium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/enderium.json
@@ -40,5 +40,5 @@
       "count": 4
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/invar.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/invar.json
@@ -25,5 +25,5 @@
       "count": 3
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/lumium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/lumium.json
@@ -40,5 +40,5 @@
       "count": 4
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/signalum.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/signalum.json
@@ -40,5 +40,5 @@
       "count": 4
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/mixing/steel.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/mixing/steel.json
@@ -22,5 +22,5 @@
       "count": 1
     }
   ],
-  "heatRequirement": "heated"
+  "heat_requirement": "heated"
 }


### PR DESCRIPTION
This is a rather simple fix. It just changes the key `heatRequirement` (camel case) to `heat_requirement` (snake case). The latter is the correct way to specify a heat requirement, and previously this error caused all metal Mixing recipes to lack a heat requirement.