### PR TITLE
Use C namespace in Create filling recipes

### DIFF
--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_crystal.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/allthemodium"
+      "tag": "c:crystals/allthemodium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_ore.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/allthemodium"
+      "tag": "c:ores/allthemodium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_raw.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/allthemodium",
+      "tag": "c:raw_materials/allthemodium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/allthemodium_raw_block.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_allthemodium"
+      "tag": "c:storage_blocks/raw_allthemodium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/aluminum"
+      "tag": "c:crystals/aluminum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/aluminum"
+      "tag": "c:ores/aluminum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/aluminum",
+      "tag": "c:raw_materials/aluminum",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/aluminum_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_aluminum"
+      "tag": "c:storage_blocks/raw_aluminum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/copper"
+      "tag": "c:crystals/copper"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/copper"
+      "tag": "c:ores/copper"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/copper",
+      "tag": "c:raw_materials/copper",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/copper_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_copper"
+      "tag": "c:storage_blocks/raw_copper"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/gold"
+      "tag": "c:crystals/gold"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/gold"
+      "tag": "c:ores/gold"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/gold",
+      "tag": "c:raw_materials/gold",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/gold_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_gold"
+      "tag": "c:storage_blocks/raw_gold"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/iridium"
+      "tag": "c:crystals/iridium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/iridium"
+      "tag": "c:ores/iridium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/iridium",
+      "tag": "c:raw_materials/iridium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iridium_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_iridium"
+      "tag": "c:storage_blocks/raw_iridium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/iron"
+      "tag": "c:crystals/iron"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/iron"
+      "tag": "c:ores/iron"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/iron",
+      "tag": "c:raw_materials/iron",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/iron_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_iron"
+      "tag": "c:storage_blocks/raw_iron"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/lead"
+      "tag": "c:crystals/lead"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/lead"
+      "tag": "c:ores/lead"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/lead",
+      "tag": "c:raw_materials/lead",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/lead_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_lead"
+      "tag": "c:storage_blocks/raw_lead"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/nickel"
+      "tag": "c:crystals/nickel"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/nickel"
+      "tag": "c:ores/nickel"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/nickel",
+      "tag": "c:raw_materials/nickel",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/nickel_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_nickel"
+      "tag": "c:storage_blocks/raw_nickel"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/osmium"
+      "tag": "c:crystals/osmium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/osmium"
+      "tag": "c:ores/osmium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/osmium",
+      "tag": "c:raw_materials/osmium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/osmium_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_osmium"
+      "tag": "c:storage_blocks/raw_osmium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/platinum"
+      "tag": "c:crystals/platinum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/platinum"
+      "tag": "c:ores/platinum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/platinum",
+      "tag": "c:raw_materials/platinum",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/platinum_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_platinum"
+      "tag": "c:storage_blocks/raw_platinum"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/silver"
+      "tag": "c:crystals/silver"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/silver"
+      "tag": "c:ores/silver"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/silver",
+      "tag": "c:raw_materials/silver",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/silver_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_silver"
+      "tag": "c:storage_blocks/raw_silver"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/tin"
+      "tag": "c:crystals/tin"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/tin"
+      "tag": "c:ores/tin"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/tin",
+      "tag": "c:raw_materials/tin",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/tin_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_tin"
+      "tag": "c:storage_blocks/raw_tin"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_crystal.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/unobtainium"
+      "tag": "c:crystals/unobtainium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_ore.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/unobtainium"
+      "tag": "c:ores/unobtainium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_raw.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/unobtainium",
+      "tag": "c:raw_materials/unobtainium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/unobtainium_raw_block.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_unobtainium"
+      "tag": "c:storage_blocks/raw_unobtainium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/uranium"
+      "tag": "c:crystals/uranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/uranium"
+      "tag": "c:ores/uranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/uranium",
+      "tag": "c:raw_materials/uranium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/uranium_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_uranium"
+      "tag": "c:storage_blocks/raw_uranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_crystal.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/vibranium"
+      "tag": "c:crystals/vibranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_ore.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/vibranium"
+      "tag": "c:ores/vibranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_raw.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/vibranium",
+      "tag": "c:raw_materials/vibranium",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/vibranium_raw_block.json
@@ -12,7 +12,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_vibranium"
+      "tag": "c:storage_blocks/raw_vibranium"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_crystal.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_crystal.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "crystals/zinc"
+      "tag": "c:crystals/zinc"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_ore.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "ores/zinc"
+      "tag": "c:ores/zinc"
     },
     {
       "type": "fluid_tag",

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_raw.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_raw.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "raw_materials/zinc",
+      "tag": "c:raw_materials/zinc",
       "count": 3
     },
     {

--- a/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_raw_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/spout/zinc_raw_block.json
@@ -8,7 +8,7 @@
   "type": "create:filling",
   "ingredients": [
     {
-      "tag": "storage_blocks/raw_zinc"
+      "tag": "c:storage_blocks/raw_zinc"
     },
     {
       "type": "fluid_tag",


### PR DESCRIPTION
This PR is another simple fix. It adds `c:` to the beginning of the tag names in all of the new Create spouting/filling recipes; previously, the lack thereof was causing Minecraft to interpret the tags as under the `minecraft` namespace, e.g., `minecraft:raw_ores/platinum` (obviously nonexistent).