### PR TITLE
Create crushing

### DIFF
--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/allthemodium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/allthemodium_clump.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:dirty_allthemodium_dust"
-            }
+            "id": "allthemodium:dirty_allthemodium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/allthemodium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/allthemodium_ore.json
@@ -19,27 +19,19 @@
     "results": [
         {
             "count": 1,
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            }
+            "id": "allthemodium:allthemodium_dust"
         },
         {
             "chance": 0.15,
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            }
+            "id": "allthemodium:allthemodium_dust"
         },
         {
-            "chance": 1.0,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget",
+            "chance": 0.15
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_aluminum_dust"
-            }
+            "id": "alltheores:dirty_aluminum_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_ore.json
@@ -14,21 +14,15 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/aluminum_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 7,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 7,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/cinnabar_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 7,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/copper_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/copper_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_copper_dust"
-            }
+            "id": "alltheores:dirty_copper_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/copper_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/copper_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 5,
-            "item": {
-                "id": "alltheores:copper_dust"
-            }
+            "id": "create:crushed_raw_copper"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:copper_dust"
-            }
+            "id": "create:crushed_raw_copper"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_allthemodium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_allthemodium_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 1,
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            }
+            "id": "allthemodium:allthemodium_dust"
         },
         {
             "chance": 0.15,
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            }
+            "id": "allthemodium:allthemodium_dust"
         },
         {
-            "chance": 1.0,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget",
+            "chance": 0.15
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_aluminum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_aluminum_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_cinnabar_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_cinnabar_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 7,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:cinnabar"
-            }
+            "id": "alltheores:cinnabar"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_copper_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_copper_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 7,
-            "item": {
-                "id": "alltheores:copper_dust"
-            }
+            "id": "create:crushed_raw_copper"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:copper_dust"
-            }
+            "id": "create:crushed_raw_copper"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_fluorite_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_fluorite_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_gold_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_gold_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:gold_dust"
-            }
+            "id": "create:crushed_raw_gold"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:gold_dust"
-            }
+            "id": "create:crushed_raw_gold"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_iridium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_iridium_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_iron_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_iron_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:iron_dust"
-            }
+            "id": "create:crushed_raw_iron"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:iron_dust"
-            }
+            "id": "create:crushed_raw_iron"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_lead_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_lead_ore.json
@@ -8,6 +8,14 @@
     "type": "create:crushing",
     "ingredients": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "item": "alltheores:deepslate_lead_ore"
         }
     ],
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_nickel_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_nickel_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_osmium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_osmium_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_peridot_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_peridot_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_platinum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_platinum_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_ruby_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_ruby_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_salt_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_salt_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_sapphire_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_sapphire_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_silver_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_silver_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_sulfur_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_sulfur_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_tin_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_tin_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "alltheores:tin_dust"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_uranium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_uranium_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_zinc_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/deepslate_zinc_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobbled_deepslate"
-            }
+            "id": "minecraft:cobbled_deepslate"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/diamond.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/diamond.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:diamond_dust"
-            }
+            "id": "alltheores:diamond_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:fluorite_dust"
-            }
+            "id": "alltheores:fluorite_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/fluorite_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:fluorite"
-            }
+            "id": "alltheores:fluorite"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/gold_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/gold_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_gold_dust"
-            }
+            "id": "alltheores:dirty_gold_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/gold_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/gold_ore.json
@@ -14,28 +14,20 @@
     "processingTime": 250,
     "results": [
         {
-            "item": {
-                "id": "alltheores:gold_dust"
-            }
+            "id": "create:crushed_raw_gold"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:gold_dust"
-            }
+            "id": "create:crushed_raw_gold"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_iridium_dust"
-            }
+            "id": "alltheores:dirty_iridium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iridium_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,28 +27,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iron_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iron_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_iron_dust"
-            }
+            "id": "alltheores:dirty_iron_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/iron_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/iron_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 250,
     "results": [
         {
-            "item": {
-                "id": "alltheores:iron_dust"
-            }
+            "id": "create:crushed_raw_iron"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:iron_dust"
-            }
+            "id": "create:crushed_raw_iron"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_lead_dust"
-            }
+            "id": "alltheores:dirty_lead_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_end_ore.json
@@ -8,6 +8,14 @@
     "type": "create:crushing",
     "ingredients": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "item": "alltheores:end_lead_ore"
         }
     ],
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/lead_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_nickel_dust"
-            }
+            "id": "alltheores:dirty_nickel_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/nickel_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_osmium_dust"
-            }
+            "id": "alltheores:dirty_osmium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/osmium_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:peridot_dust"
-            }
+            "id": "alltheores:peridot_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/peridot_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:peridot"
-            }
+            "id": "alltheores:peridot"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_platinum_dust"
-            }
+            "id": "alltheores:dirty_platinum_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/platinum_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_allthemodium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_allthemodium.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            }
+            "id": "allthemodium:allthemodium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_allthemodium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_allthemodium_block.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:allthemodium_dust"
-            },
+            "id": "allthemodium:allthemodium_dust",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 1.0
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_aluminum.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_aluminum.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            }
+            "id": "create:crushed_raw_aluminum"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_aluminum_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_aluminum_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:aluminum_dust"
-            },
+            "id": "create:crushed_raw_aluminum",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_copper.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_copper.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:copper_dust"
-            }
+            "id": "create:crushed_raw_copper"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_copper_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_copper_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:copper_dust"
-            },
+            "id": "create:crushed_raw_copper",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_gold.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_gold.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:gold_dust"
-            }
+            "id": "create:crushed_raw_gold"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_gold_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_gold_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:gold_dust"
-            },
+            "id": "create:crushed_raw_gold",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iridium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iridium.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:iridium_dust"
-            }
+            "id": "alltheores:iridium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iridium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iridium_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:iridium_dust"
-            },
+            "id": "alltheores:iridium_dust",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iron.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iron.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:iron_dust"
-            }
+            "id": "create:crushed_raw_iron"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iron_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_iron_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:iron_dust"
-            },
+            "id": "create:crushed_raw_iron",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_lead.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_lead.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:lead_dust"
-            }
+            "id": "create:crushed_raw_lead"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_lead_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_lead_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:lead_dust"
-            },
+            "id": "create:crushed_raw_lead",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_nickel.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_nickel.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:nickel_dust"
-            }
+            "id": "create:crushed_raw_nickel"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_nickel_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_nickel_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:nickel_dust"
-            },
+            "id": "create:crushed_raw_nickel",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_osmium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_osmium.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:osmium_dust"
-            }
+            "id": "create:crushed_raw_osmium"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_osmium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_osmium_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:osmium_dust"
-            },
+            "id": "create:crushed_raw_osmium",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_platinum.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_platinum.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:platinum_dust"
-            }
+            "id": "create:crushed_raw_platinum"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_platinum_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_platinum_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:platinum_dust"
-            },
+            "id": "create:crushed_raw_platinum",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_silver.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_silver.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_silver_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_silver_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:silver_dust"
-            },
+            "id": "create:crushed_raw_silver",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_tin.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_tin.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_tin_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_tin_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:tin_dust"
-            },
+            "id": "create:crushed_raw_tin",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_unobtanium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_unobtanium.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:unobtainium_dust"
-            }
+            "id": "allthemodium:unobtainium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_unobtanium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_unobtanium_block.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:unobtainium_dust"
-            },
+            "id": "allthemodium:unobtainium_dust",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 1.0
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_uranium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_uranium.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_uranium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_uranium_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:uranium_dust"
-            },
+            "id": "create:crushed_raw_uranium",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_vibranium.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_vibranium.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            }
+            "id": "allthemodium:vibranium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_vibranium_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_vibranium_block.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            },
+            "id": "allthemodium:vibranium_dust",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 1.0
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_zinc.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_zinc.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_zinc_block.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/raw_zinc_block.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:zinc_dust"
-            },
+            "id": "create:crushed_raw_zinc",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:ruby_dust"
-            }
+            "id": "alltheores:ruby_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/ruby_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:ruby"
-            }
+            "id": "alltheores:ruby"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/salt_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:salt"
-            }
+            "id": "alltheores:salt"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:sapphire_dust"
-            }
+            "id": "alltheores:sapphire_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.75
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sapphire_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sapphire"
-            }
+            "id": "alltheores:sapphire"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_silver_dust"
-            }
+            "id": "alltheores:dirty_silver_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -14,27 +22,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/silver_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "create:crushed_raw_silver"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:silver_dust"
-            }
+            "id": "alltheores:silver_dust"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur.json
@@ -13,15 +13,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:sulfur"
-            },
+            "id": "alltheores:sulfur",
             "count": 9
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "count": 9,
             "chance": 0.75
         }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_ore.json
@@ -15,27 +15,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.12,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/sulfur_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:sulfur"
-            }
+            "id": "alltheores:sulfur"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_tin_dust"
-            }
+            "id": "alltheores:dirty_tin_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/tin_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:tin_dust"
-            }
+            "id": "create:crushed_raw_tin"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/unobtanium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/unobtanium_clump.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:dirty_unobtainium_dust"
-            }
+            "id": "allthemodium:dirty_unobtainium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/unobtanium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/unobtanium_ore.json
@@ -19,27 +19,19 @@
     "results": [
         {
             "count": 1,
-            "item": {
-                "id": "allthemodium:unobtainium_dust"
-            }
+            "id": "allthemodium:unobtainium_dust"
         },
         {
             "chance": 0.15,
-            "item": {
-                "id": "allthemodium:unobtainium_dust"
-            }
+            "id": "allthemodium:unobtainium_dust"
         },
         {
-            "chance": 1.0,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget",
+            "chance": 0.15
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_uranium_dust"
-            }
+            "id": "alltheores:dirty_uranium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,28 +23,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 400,
     "results": [
         {
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/uranium_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,28 +27,20 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "create:crushed_raw_uranium"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:uranium_dust"
-            }
+            "id": "alltheores:uranium_dust"
         },
         {
             "chance": 0.75,
             "count": 2,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_clump.json
@@ -17,15 +17,11 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "allthemodium:dirty_vibranium_dust"
-            }
+            "id": "allthemodium:dirty_vibranium_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
-            "chance": 1.0
+            "id": "create:experience_nugget",
+            "chance": 0.15
         }
     ],
     "processingTime": 800

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_ore.json
@@ -19,27 +19,19 @@
     "results": [
         {
             "count": 1,
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            }
+            "id": "allthemodium:vibranium_dust"
         },
         {
             "chance": 0.15,
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            }
+            "id": "allthemodium:vibranium_dust"
         },
         {
-            "chance": 1.0,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget",
+            "chance": 0.15
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/vibranium_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 1,
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            }
+            "id": "allthemodium:vibranium_dust"
         },
         {
             "chance": 0.15,
-            "item": {
-                "id": "allthemodium:vibranium_dust"
-            }
+            "id": "allthemodium:vibranium_dust"
         },
         {
-            "chance": 1.0,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget",
+            "chance": 0.15
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_clump.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_clump.json
@@ -13,14 +13,10 @@
     ],
     "results": [
         {
-            "item": {
-                "id": "alltheores:dirty_zinc_dust"
-            }
+            "id": "alltheores:dirty_zinc_dust"
         },
         {
-            "item": {
-                "id": "create:experience_nugget"
-            },
+            "id": "create:experience_nugget",
             "chance": 0.5
         }
     ],

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_end_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_end_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:end_stone"
-            }
+            "id": "minecraft:end_stone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_nether_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_nether_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         }
@@ -15,27 +23,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:netherrack"
-            }
+            "id": "minecraft:netherrack"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_ore.json
@@ -14,27 +14,19 @@
     "processingTime": 250,
     "results": [
         {
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "minecraft:cobblestone"
-            }
+            "id": "minecraft:cobblestone"
         }
     ]
 }

--- a/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_other_ore.json
+++ b/src/main/resources/data/allthecompatibility/recipe/create/crushing/zinc_other_ore.json
@@ -1,6 +1,14 @@
 {
     "neoforge:conditions": [
         {
+            "type": "neoforge:not",
+            "value": {
+                "type": "neoforge:mod_loaded",
+                "modid": "almostunified"
+
+            }
+        },
+        {
             "type": "neoforge:mod_loaded",
             "modid": "create"
         },
@@ -19,27 +27,19 @@
     "results": [
         {
             "count": 2,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.25,
-            "item": {
-                "id": "alltheores:zinc_dust"
-            }
+            "id": "create:crushed_raw_zinc"
         },
         {
             "chance": 0.75,
-            "item": {
-                "id": "create:experience_nugget"
-            }
+            "id": "create:experience_nugget"
         },
         {
             "chance": 0.125,
-            "item": {
-                "id": "allthemodium:ancient_stone"
-            }
+            "id": "allthemodium:ancient_stone"
         }
     ]
 }


### PR DESCRIPTION
fix(recipes): Remove redundant "item": {} in crushing recipes
  Closes [#24](https://github.com/XxRexRaptorxX/AllTheCompatibility/issues/24)
fix(recipes): Crushed ore variants (aluminum, copper, gold, iron, lead, nickel, osmium, platinum, silver, tin, uranium, and zinc) drop from crushing ore variants fix(compatability): Ore crushing recipes only load stone -> dust/clump if Almost Unified is present, limiting conflicts with crushing recipe mergers fix(recipes): Experience nuggets drop at a 75% chance in recipes that prior dropped at an 100% chance